### PR TITLE
Update organizr image from deprecated one

### DIFF
--- a/tasks/organizr.yml
+++ b/tasks/organizr.yml
@@ -10,7 +10,7 @@
 - name: Create Organizr container
   docker_container:
     name: organizr
-    image: organizrtools/organizr-v2:latest
+    image: organizr/organizr:latest
     pull: true
     volumes:
       - "{{ organizr_data_directory }}:/config:rw"


### PR DESCRIPTION
**What this PR does / why we need it**:
https://hub.docker.com/r/organizrtools/organizr-v2 was not working and is deprecated, used organizr/organizr as recommended instead


**Which issue (if any) this PR fixes**:
n/a

**Any other useful info**:
n/a